### PR TITLE
Expand name table

### DIFF
--- a/_includes/tenkenReplacer.html
+++ b/_includes/tenkenReplacer.html
@@ -4,14 +4,44 @@
 </div>
 
 <script>
-let choiceList = [0, 0, 0, 0, 0];
+let choiceList = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
 let nameTable = [
 	["Master", "Teacher"],
 	["Urushi", "Jet"],
+	["Alistair", "Aristea"],
+	["Ashwrath", "Urslars"],
+	["Bulbora", "Bulbola"],
+	["Khanna", "Carna"],
+	["Diaz", "Dias"],
+	["Dovey", "du Vix"],
+	["Elebent", "Elevent"],
+	["Elsa", "Elza"],
+	["Eliante", "Erianthe"],
+	["Fanatics", "Fanatix"],
+	["Felmus", "Phelms"],
+	["Flut", "Fult"],
+	["Forrund", "Forlund"],
+	["Gamudo", "Gammod"],
+	["Gordicia", "Goldicia"],
+	["Intelligence Weapon", "Intelligent Weapon"],
+	["Intelligence Weapons", "Intelligent Weapons"],
+	["Jilbard", "Jillbird"],
+	["Kranzel", "Granzell"],
+	["Ladur", "Radule"],
+	["Lady Blue", "Ladyblue"],
+	["Weena Rhyn", "Winalene"],  // Not alphabetical to give it priority over Rhyn.
+	["Rhyn", "Lene"],
+	["Rigdis", "Rigdith"],
+	["Satia", "Satya"],
+	["Seedran", "Seedrun"],
+	["Sword God Transformation", "Sword God Form"],
+	["Weena", "Wina"],
+	["Zefmate", "Zehmet"],
+	["Zelos Reed", "Theraclede"],
 ];
 
-let tableVersion = 1;
+let tableVersion = 2;
 
 function changeName() {
 	choiceId = arguments[0];

--- a/_includes/tenkenReplacer.html
+++ b/_includes/tenkenReplacer.html
@@ -30,13 +30,13 @@ let nameTable = [
 	["Kranzel", "Granzell"],
 	["Ladur", "Radule"],
 	["Lady Blue", "Ladyblue"],
-	["Weena Rhyn", "Winalene"],  // Not alphabetical to give it priority over Rhyn.
 	["Rhyn", "Lene"],
 	["Rigdis", "Rigdith"],
 	["Satia", "Satya"],
 	["Seedran", "Seedrun"],
 	["Sword God Transformation", "Sword God Form"],
 	["Weena", "Wina"],
+	["Weena Rhyn", "Winalene"],
 	["Zefmate", "Zehmet"],
 	["Zelos Reed", "Theraclede"],
 ];
@@ -76,7 +76,18 @@ function init() {
 
 	var element = document.getElementsByClassName("post-content e-content")[0];
 
-	for (const [choiceId, nameList] of nameTable.entries())
+	// The terms Weena and Rhyn are substrings of the longer term Weena Rhyn,
+	// this causes the shorter terms to be nested inside the longer one
+	// when the changer spans are added. To avoid this, we need to temporarily
+	// replace the longer term with a placeholder, to prevent it from matching
+	// the shorter ones later on, meaning we need to sort them by length before processing.
+
+	var replacements = {};
+
+	// Sort nameTable by the length of the original name.
+	nameTable.sort((a, b) => b[0].length - a[0].length);
+
+	for (const [choiceId, nameList] of nameTable.entries()) 
 	{
 		if (choiceId >= choiceList.length) {
 			continue;
@@ -85,10 +96,21 @@ function init() {
 		if (choiceList[choiceId] >= nameList.length) {
 			continue;
 		}
-		
-		var re = new RegExp(nameList[0] + "\\b", "g");
-		element.innerHTML = element.innerHTML.replace(re, '<span onclick="changeName(' + choiceId + ')">' + nameList[0] + '</span>');
-		element.innerHTML = element.innerHTML.replace(re, nameList[choiceList[choiceId]]);
+
+		var originalName = nameList[0];
+		var replacementName = nameList[choiceList[choiceId]];
+
+		var placeholder = `%%PLACEHOLDER_${choiceId}%%`;
+		replacements[placeholder] = `<span onclick="changeName(${choiceId})">${replacementName}</span>`;
+
+		var re = new RegExp(`\\b${originalName}\\b`, "g");
+
+		element.innerHTML = element.innerHTML.replace(re, placeholder);	
+	}
+
+	// Replace all placeholders with their final replacements.
+	for (const [placeholder, finalReplacement] of Object.entries(replacements)) {
+		element.innerHTML = element.innerHTML.replace(new RegExp(placeholder, 'g'), finalReplacement);
 	}
 }
 

--- a/_includes/tenkenReplacer.html
+++ b/_includes/tenkenReplacer.html
@@ -109,7 +109,8 @@ function init() {
 	}
 
 	// Replace all placeholders with their final replacements.
-	for (const [placeholder, finalReplacement] of Object.entries(replacements)) {
+	for (const [placeholder, finalReplacement] of Object.entries(replacements)) 
+	{
 		element.innerHTML = element.innerHTML.replace(new RegExp(placeholder, 'g'), finalReplacement);
 	}
 }

--- a/_posts/Tenken0700/2022-09-15-chapter-0756.markdown
+++ b/_posts/Tenken0700/2022-09-15-chapter-0756.markdown
@@ -96,7 +96,7 @@ Is she worried because it's such a dangerous place? No, it feels a little differ
 
 「For Master?」
 
-『Yeah, Trismegistus is said to have an intelligence weapon. Since I'm one as well, I'd like to meet them and have a talk.』
+『Yeah, Trismegistus is said to have an Intelligence Weapon. Since I'm one as well, I'd like to meet them and have a talk.』
 
 I don't need to worry Amanda unnecessarily by telling her about how I might eventually go insane.
 


### PR DESCRIPTION
Here are (as far as proper names are concerned, I think) all differences for readers coming from the light novels.
I made sure to check how the replacement logic functions, and as far as I can tell, it simply iterates over all 
names in order of the nameTable and attempts to find the regex pattern `name` with `\b` appended, 
to ensure there is a word boundary.
This is all well and good for proper names, but doesn't work for words that aren't always capitalized or
sometimes come with plural forms, so I made no attempt to include other terms like "divine sword" ->
"Godsword", with the exception of Intelligence Weapon(s) due to it being capitalized, meaning only 2 variations
needed to be considered to support the singular and plural forms.
For the latter I also changed the one time Intelligence Weapon wasn't capitalized, to match with the other occurrences.

With this, I hope to help people coming from the light novels who are unsure about who some of the names
refer to, since some of them like Ashwrath, Ladur, Rhyn, and Zelos Reed are vastly different.

In testing I noticed that Weena Rhyn and both parts separately existing at the same time wasn't so easily
handled as I would have hoped, resulting in nested replacement spans. So I whipped up a fix that first performs
a replacement with a placeholder, thus removing the possibility of the shorter substrings matching
inside the longer one. Then undoing the placeholders after all of them were assigned.

In testing there was 0 extra slowdown before/after this patch, build times aren't impacted. 